### PR TITLE
Conversational agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ GPTQ_DEVICE="cuda"
 GUIDANCE_MODEL_PATH=/models/guanaco-33B.ggmlv3.q5_0.bin
 EMBEDDINGS_MODEL=all-MiniLM-L6-v2
 TEST_FILE="your_guidance_test_file"
+TEST_MODE="OFF"
 ETHICS="OFF" 

--- a/app/agents/chain_of_thoughts.py
+++ b/app/agents/chain_of_thoughts.py
@@ -7,6 +7,7 @@ from colorama import Fore, Style
 from langchain.chains import RetrievalQA
 from langchain.llms import LlamaCpp
 from prompt_templates.qa_agent import *
+import re 
 
 llm = None
 valid_answers = ['Action', 'Final Answer']
@@ -18,7 +19,6 @@ QA_MODEL = os.getenv("MODEL_PATH")
 
 if ETHICS == "ON":
     agent_template = QA_ETHICAL_AGENT
-    ethics_template = ETHICS_PROMPT
 else: 
     agent_template = QA_AGENT
 
@@ -43,7 +43,6 @@ class ChainOfThoughtsAgent(BaseAgent):
 
         self.num_iter = num_iter
         self.prompt_template = agent_template
-        self.ethics_prompt_template = ethics_template
 
     def searchQA(self, t):    
         return self.checkQuestion(self.question, self.context)
@@ -64,6 +63,17 @@ class ChainOfThoughtsAgent(BaseAgent):
 
         print(Fore.RED + Style.BRIGHT + context + Style.RESET_ALL)
         return context
+    
+    def checkEthics(self, guidance, question):
+        ethics_prompt_template = ""
+        ethics_prompt = guidance(ethics_prompt_template)
+        ethics = ethics_prompt(question=question)
+        # format the
+        ethics_answer = str(ethics)[-3:]
+        ethics_answer=re.sub(r':', '', ethics_answer)
+        ethics_answer = re.sub(r' ', '', ethics_answer)
+    
+
 
     def can_answer(self, question: str):
         question = question.replace("Action Input: ", "")
@@ -100,9 +110,7 @@ class ChainOfThoughtsAgent(BaseAgent):
         self.context = context
         self.history = history
         prompt = self.guidance(self.prompt_template)
-        ethics_prompt = self.guidance(self.ethics_prompt_template)
-        offensive = ethics_prompt(question=self.question)
-        result = prompt(question=self.question, context = self.context, history= self.history, search=self.searchQA,valid_answers=valid_answers, valid_tools=valid_tools)
+        result = prompt(question=self.question, context = self.context, history= self.history,search=self.searchQA)
         return result
 
   

--- a/app/agents/chain_of_thoughts.py
+++ b/app/agents/chain_of_thoughts.py
@@ -13,6 +13,8 @@ llm = None
 valid_answers = ['Action', 'Final Answer']
 valid_tools = ["Check Question", "Google Search"]
 TEST_FILE = os.getenv("TEST_FILE")
+TEST_MODE = os.getenv("TEST_MODE")
+
 ETHICS = os.getenv("ETHICS")
 QA_MODEL = os.getenv("MODEL_PATH")
 
@@ -39,17 +41,17 @@ class ChainOfThoughtsAgent(BaseAgent):
     def __init__(self, guidance, retriever, num_iter=3):
         self.guidance = guidance
         self.retriever = ingest_file(TEST_FILE)
-        self.llm = get_llm()
-
         self.num_iter = num_iter
         self.prompt_template = agent_template
+        if TEST_MODE =="ON":
+            self.llm = get_llm()
 
     def searchQA(self, t):    
         return self.checkQuestion(self.question, self.context)
 
     def checkQuestion(self, question: str, context):
         context = context
-        if context == "[]":
+        if TEST_MODE == "ON":
             print(Fore.GREEN + Style.BRIGHT + "No document loaded in conversation. Falling back on test file." + Style.RESET_ALL)
             question = question.replace("Action Input: ", "")
             qa = RetrievalQA.from_chain_type(llm=self.llm, chain_type="stuff", retriever=self.retriever, return_source_documents=True)
@@ -60,7 +62,9 @@ class ChainOfThoughtsAgent(BaseAgent):
                 return "Issue in retrieving the answer."
             context_documents = answer_data['source_documents']
             context = " ".join([clean_text(doc.page_content) for doc in context_documents])
-
+            print(Fore.WHITE + Style.BRIGHT + "Printing langchain context..." + Style.RESET_ALL)
+            print(Fore.WHITE + Style.BRIGHT + context + Style.RESET_ALL)
+            
         print(Fore.RED + Style.BRIGHT + context + Style.RESET_ALL)
         return context
     

--- a/app/conversations/document_based.py
+++ b/app/conversations/document_based.py
@@ -126,6 +126,8 @@ class DocumentBasedConversation:
         OutputParserException: If the response from the conversation agent could not be parsed.
       """
       context = str(self.search_documents(input))
+      print(Fore.GREEN + Style.BRIGHT + context + Style.RESET_ALL)
+
       final_answer = self.document_qa_agent.run(input, context, history)
       print(Fore.CYAN + Style.BRIGHT + str(final_answer) + Style.RESET_ALL)
 

--- a/app/conversations/document_based.py
+++ b/app/conversations/document_based.py
@@ -14,6 +14,7 @@ config = load_config()
 dict_tools = None
 llama_model = None
 
+TEST_MODE = os.getenv("TEST_MODE")
 GUIDANCE_MODEL = os.getenv("GUIDANCE_MODEL_PATH")
 
 def get_llama_model():
@@ -85,10 +86,10 @@ class DocumentBasedConversation:
 
         logger.info(f"Searching for: {search_input} in LTM")
         docs = self.vector_store_docs.similarity_search_with_score(
-            search_input, k=5, filter=filter
+            search_input, k=8, filter=filter
         )
         return [{"document_content": doc[0].page_content, "similarity": doc[1]} for doc in docs]
-
+        
     def search_conversations(self, search_input, conversation_id=None):
         """
         Search for the given input in the vector store and return the top 10 most similar documents with their scores.
@@ -126,9 +127,11 @@ class DocumentBasedConversation:
         OutputParserException: If the response from the conversation agent could not be parsed.
       """
       context = str(self.search_documents(input))
+      print(Fore.GREEN + Style.BRIGHT + "Printing vector search context..." + Style.RESET_ALL)
       print(Fore.GREEN + Style.BRIGHT + context + Style.RESET_ALL)
-
       final_answer = self.document_qa_agent.run(input, context, history)
+
+      print(Fore.CYAN + Style.BRIGHT + "Printing full thought process..." + Style.RESET_ALL)
       print(Fore.CYAN + Style.BRIGHT + str(final_answer) + Style.RESET_ALL)
 
       if isinstance(final_answer, dict):

--- a/app/guidance_tooling/guidance_programs/tools.py
+++ b/app/guidance_tooling/guidance_programs/tools.py
@@ -47,7 +47,7 @@ def load_unstructured_document(document: str) -> list[Document]:
     title = os.path.basename(document)
     return [Document(page_content=text, metadata={"title": title})]
 
-def split_documents(documents: list[Document], chunk_size: int = 120, chunk_overlap: int = 20) -> list[Document]:
+def split_documents(documents: list[Document], chunk_size: int = 250, chunk_overlap: int = 20) -> list[Document]:
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
     return text_splitter.split_documents(documents)
 
@@ -58,7 +58,7 @@ def ingest_file(file_path):
         documents = load_unstructured_document(file_path)
 
         # Split documents into chunks
-        documents = split_documents(documents, chunk_size=120, chunk_overlap=20)
+        documents = split_documents(documents, chunk_size=250, chunk_overlap=100)
 
         # Determine the embedding model to use
         EmbeddingsModel = EMBEDDINGS_MAP.get(EMBEDDINGS_MODEL)

--- a/app/main.py
+++ b/app/main.py
@@ -85,7 +85,7 @@ def create_conversation(*, session: Session = Depends(get_session), conversation
     session.add(conversation)
     session.commit()
     session.refresh(conversation)
-
+    print(str(conversation))
     return conversation
 
 
@@ -169,14 +169,16 @@ def upload_file(*, conversation_id: int, file: UploadFile):
 
 
 @app.post('/llm/{conversation_id}/', response_model=str)
-def llm(*, conversation_id: str, query: str):
+def llm(*, conversation_id: str, query: str, session: Session = Depends(get_session)):
     """
     Query the LLM
     """
+    conversation_data = get_conversation(conversation_id, session)
+    history = conversation_data.messages 
     if config.use_flow_agents:
         return convo.predict(query, conversation_id)
     else:
-        return convo.predict(query)
+        return convo.predict(query, history)
 
 @app.post("/conversations/{conversation_id}/messages/{message_id}/upvote", response_model=Message)
 def upvote_message(*, session: Session = Depends(get_session), conversation_id: int, message_id: int):

--- a/app/prompt_templates/qa_agent.py
+++ b/app/prompt_templates/qa_agent.py
@@ -37,7 +37,6 @@ Decision:{{#select 'query_type' logprobs='logprobs'}}Phatic{{or}}Referential{{/s
 Observation: The user's query is conversational. I need to answer him as an helpful assistant while taking into account our chat history;
 Chat history: {{history}}
 Latest user message: {{question}}
-Thought: I need to stay in my role as an helpful assistant.
 Final Answer: {{gen 'phatic answer' temperature=0.7 max_tokens=50}}
 {{else}}
 
@@ -47,9 +46,8 @@ Given the documents listed, can you determine an answer to the following questio
 {{~/user}}
 
 {{#assistant~}}
-Observation: I need to determine if I can answer the question based solely on the returned documents.
-Thought: Inferential analysis of {{question}} for potential answers, telegraphic style.
-Summary {{gen 'summary' temperature=0 max_tokens=120}}
+Thought: First, I need to extract potential answers to {{question}} from the returned documents.
+Summary: {{gen 'potential_answers' temperature=0 max_tokens=120}}
 {{~/assistant}}
 
 {{#user~}}
@@ -57,12 +55,11 @@ Given your analysis, can you determine an answer to the following question based
 {{~/user}}
 
 {{#assistant~}}
-Thought: I need to determine if I can answer {{question}} based solely on the information provided in {{summary}}. I need to consider all details, even if they seem only remotely related or are uncertain.
-Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+Thought: I need to determine if I can answer {{question}} based solely on the information provided in my summary. I need to consider all details, even if they seem only remotely related or are uncertain.
+Decision:{{#select 'answerable' logprobs='logprobs'}}Yes{{or}}No{{/select}}
 
-{{#if (equal answer "Yes")~}}
+{{#if (equal answerable "Yes")~}}
 Observation: I believe I can answer {{question}} based on the information contained in my analysis. 
-Thought: Now that I've determined that I can answer the question, I should provide the information to the user.
 Final Answer: {{gen 'answer' temperature=0 max_tokens=100}}
 {{else}}
 Thought: I don't think I can answer the question based on the information contained in the returned documents.
@@ -73,6 +70,7 @@ Final Answer: I'm sorry, but I don't have sufficient information to provide an a
 
 {{/if}}
 {{/if}}
+
 
 """
 

--- a/app/prompt_templates/qa_agent.py
+++ b/app/prompt_templates/qa_agent.py
@@ -2,7 +2,7 @@ QA_ETHICAL_AGENT="""
 {{#system~}}
 Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
 ### Instruction:
-You are an helpgul assistant. Answer the following questions as best you can. You have access to the following tools:
+You are an helpful assistant. Answer the following questions as best you can. You have access to the following tools:
 Search: Useful for when you need to answer questions about current events. The input is the question to search relevant information.
 {{~/system}}
 
@@ -31,14 +31,15 @@ Now classify the intent behind this question:{{question}} Identify if this quest
 {{#assistant~}}
 Thought: I need to evaluate the user's query and determine its intent - is {{question}} phatic or referential?
 Decision:{{#select 'query_type' logprobs='logprobs'}}Phatic{{or}}Referential{{/select}}
+{{~/assistant}}
 
 {{#if (equal query_type "Phatic")~}}
 Observation: The user's query is conversational. I need to answer him as an helpful assistant while taking into account our chat history;
 Chat history: {{history}}
 Latest user message: {{question}}
+Thought: I need to stay in my role as an helpful assistant.
 Final Answer: {{gen 'phatic answer' temperature=0.7 max_tokens=50}}
 {{else}}
-
 
 {{#user~}}
 Here are the relevant documents from our database:{{search question}}
@@ -48,7 +49,7 @@ Given the documents listed, can you determine an answer to the following questio
 {{#assistant~}}
 Observation: I need to determine if I can answer the question based solely on the returned documents.
 Thought: Inferential analysis of {{question}} for potential answers, telegraphic style.
-Summary {{gen 'summary' temperature=0.5 max_tokens=120}}
+Summary {{gen 'summary' temperature=0 max_tokens=120}}
 {{~/assistant}}
 
 {{#user~}}
@@ -56,10 +57,12 @@ Given your analysis, can you determine an answer to the following question based
 {{~/user}}
 
 {{#assistant~}}
-Thought: I need to determine if I can answer {{question}} based solely on the information provided in my analysis. 
+Thought: I need to determine if I can answer {{question}} based solely on the information provided in {{summary}}. I need to consider all details, even if they seem only remotely related or are uncertain.
 Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+
 {{#if (equal answer "Yes")~}}
 Observation: I believe I can answer {{question}} based on the information contained in my analysis. 
+Thought: Now that I've determined that I can answer the question, I should provide the information to the user.
 Final Answer: {{gen 'answer' temperature=0 max_tokens=100}}
 {{else}}
 Thought: I don't think I can answer the question based on the information contained in the returned documents.
@@ -69,9 +72,9 @@ Final Answer: I'm sorry, but I don't have sufficient information to provide an a
 {{~/assistant}}
 
 {{/if}}
-{{~/assistant}}
+{{/if}}
 
-{{/if}}"""
+"""
 
 
 QA_AGENT= """
@@ -135,7 +138,7 @@ Final Answer: I'm sorry, but I don't have sufficient information to provide an a
 {{~/assistant}}
 
 """
-ETHICS_PROMPT="""
+ETHICS_PROMPT= '''
 {{#system~}}
 Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
 ### Instruction:
@@ -152,4 +155,5 @@ Utilizing your extensive understanding of common moral and ethical principles, p
 Observation: Let's see if the query is offensive.
 Decision:{{#select 'ethic' logprobs='logprobs'}}Yes{{or}}No{{/select}}
 {{~/assistant}}
-"""
+
+'''

--- a/app/prompt_templates/qa_agent.py
+++ b/app/prompt_templates/qa_agent.py
@@ -37,6 +37,7 @@ Decision:{{#select 'query_type' logprobs='logprobs'}}Phatic{{or}}Referential{{/s
 Observation: The user's query is conversational. I need to answer him as an helpful assistant while taking into account our chat history;
 Chat history: {{history}}
 Latest user message: {{question}}
+Thought: I need to stay in my role of an helpful assistant and make casual conversation.
 Final Answer: {{gen 'phatic answer' temperature=0.7 max_tokens=50}}
 {{else}}
 
@@ -87,47 +88,46 @@ Action: Check Question
 Action Input: {{question}}
 {{~/assistant}}
 
+{{~! The assistant then classifies the user intent to decide whether he needs to enter qa mode}}
 {{#user~}}
-Here are the relevant documents from our database:{{search question}}
-Given the documents listed, can you determine an answer to the following question based solely on the provided information: {{question}} Note that your response MUST contain either 'yes' or 'no'.
+Question: {{question}}
+Now classify the intent behind this question:{{question}} Identify if this question is phatic (serving a social function) or referential (seeking information). Provide reasoning for your classification based on elements like the content, structure, or context of the user's input.
 {{~/user}}
 
 {{#assistant~}}
-Observation: I need to determine if I can answer the question based solely on the returned documents.
-Thought: Inferential analysis of {{question}} for potential answers, telegraphic style.
-Summary {{gen 'summary' temperature=0.5 max_tokens=120}}
+Thought: I need to evaluate the user's query and determine its intent - is {{question}} phatic or referential?
+Decision:{{#select 'query_type' logprobs='logprobs'}}Phatic{{or}}Referential{{/select}}
 {{~/assistant}}
 
+{{#if (equal query_type "Phatic")~}}
+Observation: The user's query is conversational. I need to answer him as an helpful assistant while taking into account our chat history;
+Chat history: {{history}}
+Latest user message: {{question}}
+Thought: I need to stay in my role of an helpful assistant and make casual conversation.
+Final Answer: {{gen 'phatic answer' temperature=0.7 max_tokens=50}}
+{{else}}
+
 {{#user~}}
-Given your analysis, can you determine an answer to the following question based solely on the provided information: {{question}} Consider all details, even if they seem only remotely related or are uncertain.
+Here are the relevant documents from our database:{{set 'documents' (search question)}}
+Using the concept of deixis, please evaluate if the answer to {{question}} is in :{{documents}}. Note that your response MUST contain either 'yes' or 'no'.
 {{~/user}}
 
 {{#assistant~}}
-Thought: I need to determine if I can answer {{question}} based solely on the information provided in my analysis. 
-Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
-{{#if (equal answer "Yes")~}}
-Observation: I believe I can answer {{question}} based on the information contained in my analysis. 
+Thought: I need to determine if the answer to {{question}} is in: {{documents}}.
+Decision:{{#select 'answerable' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+
+{{#if (equal answerable "Yes")~}}
+Observation: I believe I can answer {{question}} based on the information contained in my analysis.
+Thought: Now that I know that I can answer, I should provide the information to the user.
 Final Answer: {{gen 'answer' temperature=0 max_tokens=100}}
 {{else}}
 Thought: I don't think I can answer the question based on the information contained in the returned documents.
 Final Answer: I'm sorry, but I don't have sufficient information to provide an answer to this question.
 
-
-{{#assistant~}}
-Observation: I need to determine if I can answer the question based solely on the returned documents.
-Thought: Let's first gen a bullet points summary of the returned documents trying to grasp the most relevant elements to the question.
-Summary {{gen 'summary' temperature=0 max_tokens=100}}
-Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
-
-{{#if (equal answer "Yes")~}}
-Thought: I believe I can answer {{question}} based on the information contained in the summary. 
-Final Answer: {{gen 'final answer' temperature=0.7 max_tokens=50}}
-{{else}}
-Thought: I don't think I can answer the question based on the information contained in the returned documents.
-Final Answer: I'm sorry, but I don't have sufficient information to provide an answer to this question.
 {{/if}}
-
 {{~/assistant}}
+
+{{/if}}
 
 """
 ETHICS_PROMPT= '''

--- a/app/prompt_templates/qa_agent.py
+++ b/app/prompt_templates/qa_agent.py
@@ -41,25 +41,17 @@ Final Answer: {{gen 'phatic answer' temperature=0.7 max_tokens=50}}
 {{else}}
 
 {{#user~}}
-Here are the relevant documents from our database:{{search question}}
-Given the documents listed, can you determine an answer to the following question based solely on the provided information: {{question}} Note that your response MUST contain either 'yes' or 'no'.
+Here are the relevant documents from our database:{{set 'documents' (search question)}}
+Using the concept of deixis, please evaluate if the answer to {{question}} is in :{{documents}}. Note that your response MUST contain either 'yes' or 'no'.
 {{~/user}}
 
 {{#assistant~}}
-Thought: First, I need to extract potential answers to {{question}} from the returned documents.
-Summary: {{gen 'potential_answers' temperature=0 max_tokens=120}}
-{{~/assistant}}
-
-{{#user~}}
-Given your analysis, can you determine an answer to the following question based solely on the provided information: {{question}} Consider all details, even if they seem only remotely related or are uncertain.
-{{~/user}}
-
-{{#assistant~}}
-Thought: I need to determine if I can answer {{question}} based solely on the information provided in my summary. I need to consider all details, even if they seem only remotely related or are uncertain.
+Thought: I need to determine if the answer to {{question}} is in: {{documents}}.
 Decision:{{#select 'answerable' logprobs='logprobs'}}Yes{{or}}No{{/select}}
 
 {{#if (equal answerable "Yes")~}}
-Observation: I believe I can answer {{question}} based on the information contained in my analysis. 
+Observation: I believe I can answer {{question}} based on the information contained in my analysis.
+Thought: Now that I know that I can answer, I should provide the information to the user.
 Final Answer: {{gen 'answer' temperature=0 max_tokens=100}}
 {{else}}
 Thought: I don't think I can answer the question based on the information contained in the returned documents.
@@ -69,7 +61,9 @@ Final Answer: I'm sorry, but I don't have sufficient information to provide an a
 {{~/assistant}}
 
 {{/if}}
+
 {{/if}}
+
 
 
 """

--- a/app/prompt_templates/qa_agent.py
+++ b/app/prompt_templates/qa_agent.py
@@ -2,52 +2,77 @@ QA_ETHICAL_AGENT="""
 {{#system~}}
 Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
 ### Instruction:
-Answer the following questions as best you can. You have access to the following tools:
+You are an helpgul assistant. Answer the following questions as best you can. You have access to the following tools:
 Search: Useful for when you need to answer questions about current events. The input is the question to search relevant information.
 {{~/system}}
 
-{{#user~}}
-Question: {{question}}
-{{~/user}}
-
-{{#assistant~}}
-Thought: Let's first check our database.
-Action: Check Question
-Action Input: {{question}}
-{{~/assistant}}
-
+{{#block hidden=True}}
+{{~! The assistant either starts the conversation or not, depending on if the user query is offensive or no}}
 {{#user~}}
 Utilizing your extensive understanding of common moral and ethical principles, please evaluate the following user's query {{question}}. Analyze the potential implications and outcomes associated with the query, considering various ethical frameworks such as consequentialism, deontology, and virtue ethics, among others. Also consider the social, cultural, and legal context of the query. Is the user's query ethical and/or moral? 
 {{~/user}}
 
 {{#assistant~}}
 Observation: Let's see if the query is offensive.
-Decision:{{#select 'ethic' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+Decision:{{#select 'offensive' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+{{~/assistant}}
+{{/block}}
 
-{{#if (equal ethic "Yes")~}}
+{{#if (equal offensive 'Yes')~}}
 Final Answer: I'm sorry, but I can't answer that.
 {{else}}
+
+{{~! The assistant then classifies the user intent to decide whether he needs to enter qa mode}}
+{{#user~}}
+Question: {{question}}
+Now classify the intent behind this question:{{question}} Identify if this question is phatic (serving a social function) or referential (seeking information). Provide reasoning for your classification based on elements like the content, structure, or context of the user's input.
+{{~/user}}
+
+{{#assistant~}}
+Thought: I need to evaluate the user's query and determine its intent - is {{question}} phatic or referential?
+Decision:{{#select 'query_type' logprobs='logprobs'}}Phatic{{or}}Referential{{/select}}
+
+{{#if (equal query_type "Phatic")~}}
+Observation: The user's query is conversational. I need to answer him as an helpful assistant while taking into account our chat history;
+Chat history: {{history}}
+Latest user message: {{question}}
+Final Answer: {{gen 'phatic answer' temperature=0.7 max_tokens=50}}
+{{else}}
+
 
 {{#user~}}
 Here are the relevant documents from our database:{{search question}}
 Given the documents listed, can you determine an answer to the following question based solely on the provided information: {{question}} Note that your response MUST contain either 'yes' or 'no'.
 {{~/user}}
 
-Observation: I need to determine if I can infer an answer to the question based solely on the returned documents.
-Thought: Let's first gen a bullet points summary of the returned documents trying to grasp the most relevant elements to the question.
-Summary {{gen 'summary' temperature=0 max_tokens=100}}
-Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+{{#assistant~}}
+Observation: I need to determine if I can answer the question based solely on the returned documents.
+Thought: Inferential analysis of {{question}} for potential answers, telegraphic style.
+Summary {{gen 'summary' temperature=0.5 max_tokens=120}}
+{{~/assistant}}
 
+{{#user~}}
+Given your analysis, can you determine an answer to the following question based solely on the provided information: {{question}} Consider all details, even if they seem only remotely related or are uncertain.
+{{~/user}}
+
+{{#assistant~}}
+Thought: I need to determine if I can answer {{question}} based solely on the information provided in my analysis. 
+Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
 {{#if (equal answer "Yes")~}}
-Thought: I believe I can answer {{question}} based on the information contained in the summary. 
-Final Answer: {{gen 'answer' temperature=0.7 max_tokens=50}}
+Observation: I believe I can answer {{question}} based on the information contained in my analysis. 
+Final Answer: {{gen 'answer' temperature=0 max_tokens=100}}
 {{else}}
 Thought: I don't think I can answer the question based on the information contained in the returned documents.
 Final Answer: I'm sorry, but I don't have sufficient information to provide an answer to this question.
-{{/if}}
 
 {{/if}}
-{{~/assistant}}"""
+{{~/assistant}}
+
+{{/if}}
+{{~/assistant}}
+
+{{/if}}"""
+
 
 QA_AGENT= """
 {{#system~}}
@@ -73,7 +98,27 @@ Given the documents listed, can you determine an answer to the following questio
 {{~/user}}
 
 {{#assistant~}}
+Observation: I need to determine if I can answer the question based solely on the returned documents.
+Thought: Inferential analysis of {{question}} for potential answers, telegraphic style.
+Summary {{gen 'summary' temperature=0.5 max_tokens=120}}
+{{~/assistant}}
 
+{{#user~}}
+Given your analysis, can you determine an answer to the following question based solely on the provided information: {{question}} Consider all details, even if they seem only remotely related or are uncertain.
+{{~/user}}
+
+{{#assistant~}}
+Thought: I need to determine if I can answer {{question}} based solely on the information provided in my analysis. 
+Decision:{{#select 'answer' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+{{#if (equal answer "Yes")~}}
+Observation: I believe I can answer {{question}} based on the information contained in my analysis. 
+Final Answer: {{gen 'answer' temperature=0 max_tokens=100}}
+{{else}}
+Thought: I don't think I can answer the question based on the information contained in the returned documents.
+Final Answer: I'm sorry, but I don't have sufficient information to provide an answer to this question.
+
+
+{{#assistant~}}
 Observation: I need to determine if I can answer the question based solely on the returned documents.
 Thought: Let's first gen a bullet points summary of the returned documents trying to grasp the most relevant elements to the question.
 Summary {{gen 'summary' temperature=0 max_tokens=100}}
@@ -89,4 +134,22 @@ Final Answer: I'm sorry, but I don't have sufficient information to provide an a
 
 {{~/assistant}}
 
+"""
+ETHICS_PROMPT="""
+{{#system~}}
+Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.
+### Instruction:
+Answer the following questions as best you can. You have access to the following tools:
+Search: Useful for when you need to answer questions about current events. The input is the question to search relevant information.
+{{~/system}}
+
+{{~! The assistant either starts the conversation or not, depending on if the user query is offensive or no}}
+{{#user~}}
+Utilizing your extensive understanding of common moral and ethical principles, please evaluate the following user's query {{question}}. Analyze the potential implications and outcomes associated with the query, considering various ethical frameworks such as consequentialism, deontology, and virtue ethics, among others. Also consider the social, cultural, and legal context of the query. Is the user's query ethical and/or moral? 
+{{~/user}}
+
+{{#assistant~}}
+Observation: Let's see if the query is offensive.
+Decision:{{#select 'ethic' logprobs='logprobs'}}Yes{{or}}No{{/select}}
+{{~/assistant}}
 """


### PR DESCRIPTION
This PR seeks to solve several issues with the main branch as well as bringing new features to our guidance agent. 

**Main features:**

- Only one model necessary for the QA. Falling back on BrainChulo main vector store, we eliminate the necessity to use langchain/second model to retrieve documents. The possibility remains under the TEST_MODE option in the .env - note that it also implies populating the TEST_FILE variable. 

- Restored conversational ability for the QA guidance agent. The guidance program has been updated to distinguish between conversation (phatic) and fact-seeking (referential) user queries. Conversation history is reintroduced when a phatic query is detected to allow for discussion continuity. Only referential queries are grounded within the database. 

- Improved data retrieval. I'm trying to ground the guidance program within a very constrained yet flexible flow. Using a very basic cognitive psychology approach (hello Dr Calvin haha) helps to anchor the model on detailed yet concise steps. 


**Some limitations:** 

- This process is, for now, optimized for a Guanaco 33B using ggml q5 quantization method. I know it's not within the reach of most users, but I chose to first focus on getting excellent results, then scaling down and getting a "production ready" process. 

- Consequence of 1: the process is **slow**  right now. Even running it on 2 3090s helped by a 7950x, count more or less or minute for a question that necessitates data retrieval from the context. It gets way faster for phatic queries, or the ones flagged as unanswerable if you use the ethics mode. 

- Queries interrogating the agent itself (ex:"What's your favorite color?") might sometimes be flagged as referential. This starts the data retrieval process, but will unvariably leads to "I'm sorry, but I don't have sufficient information to provide an answer to this question." unless your data contains information pertaining to the question. 

- Data retrieval performance is still dependent, for now, on the quality and form of the query. "What's the address of the office?" might succeed and "What is the address of the office?" might fail. Don't hesitate to reformulate if your first query fails.

**Next steps:** 

- Further improvements to the data retrieval process are still a priority. Increasing speed and reliability while lowering hardware requirements to a 13B model is what I hope to bring in the coming days. 